### PR TITLE
fix game.destroy

### DIFF
--- a/phaser3-tutorial-src/scenes/ExampleScene.js
+++ b/phaser3-tutorial-src/scenes/ExampleScene.js
@@ -195,7 +195,7 @@ export default class ExampleScene extends Phaser.Scene {
             color: "#1e1e1e",
           })
           .setFontSize(150);
-        game.destroy();
+        this.scene.destroy();
       }
     });
   }


### PR DESCRIPTION
When I moved ExampleScene to it's own folder it does not have scope of game. therefore change it to use scene instead