### PR TITLE
Add Backend Board Clearing Functionality with Socket Events

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -67,6 +67,14 @@ io.on("connection", (socket) => {
     socket.emit("sendGameState", allGameStates[room_id]);
   });
 
+  socket.on("resetBoardServer", (room_id) => {
+    console.log("resetBoardServer server");
+    room_id = Array.from(socket.rooms)[1];
+
+    allGameStates[room_id].tilesPlayed = [];
+    io.to(room_id).emit("resetBoardClient");
+  });
+
   socket.on("disconnect", () => {
     console.log("User disconnected");
   });

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -68,7 +68,6 @@ io.on("connection", (socket) => {
   });
 
   socket.on("resetBoardServer", (room_id) => {
-    console.log("resetBoardServer server");
     room_id = Array.from(socket.rooms)[1];
 
     allGameStates[room_id].tilesPlayed = [];


### PR DESCRIPTION
## Clear Board Feature

### Server-side change:
- Added a new event `resetBoardServer` that can be triggered to clear the board on the server side.

   Example usage:
   ```javascript
   socket.emit("resetBoardServer");
   
### Client-side change:
Added a new event resetBoardClient that is emitted to everyone in the client room when the board is reset on the server.

Example usage:


```javascript
socket.on("resetBoardClient", () => {
  console.log("Code to reset everyone's board");
}); 
```