### PR TITLE
add query to endpoint '/game'

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,7 +1,7 @@
-const express = require('express');
-const http = require('http');
-const path = require('path');
-const socketIO = require('socket.io'); // CORS block interactions between client frontend and server back end, "*" mean alow all and will be considered as security fail, later need to specify and remove "*"
+const express = require("express");
+const http = require("http");
+const path = require("path");
+const socketIO = require("socket.io"); // CORS block interactions between client frontend and server back end, "*" mean alow all and will be considered as security fail, later need to specify and remove "*"
 const app = express();
 
 //const { Server } = require('socket.io');
@@ -12,25 +12,25 @@ const app = express();
   },
 });*/
 
-const cors = require('cors');
+const cors = require("cors");
 app.use(cors());
 
 const server = http.createServer(app);
 const io = socketIO(server, {
   cors: {
-    origin: '*',
-    methods: ['GET', 'POST'],
+    origin: "*",
+    methods: ["GET", "POST"],
   },
 });
-const { getHello } = require('./controllers/controllers.js');
-const { loadConfigFromFile } = require('vite');
+const { getHello } = require("./controllers/controllers.js");
+const { loadConfigFromFile } = require("vite");
 
 let roomData = {};
-if (process.env.NODE_ENV === 'development') {
-  console.log('Running in development mode');
-  roomData = require('./test/roomTestDate.js').roomTestDate;
+if (process.env.NODE_ENV === "development") {
+  console.log("Running in development mode");
+  roomData = require("./test/roomTestDate.js").roomTestDate;
 }
-// TODO add function to allGameStates to get ride of games no one is using
+// TODO add function to allGameStates to remove games no one is currently using
 /**
  * allGameStates to hold the data for all games currently being played
  * @date 20/02/2024 - 20:52:21
@@ -41,26 +41,41 @@ const allGameStates = roomData;
 
 app.use(express.json());
 
-app.use(express.static(path.join(__dirname, '../..', 'phaser3-tutorial-src')));
+app.use(express.static(path.join(__dirname, "../..", "phaser3-tutorial-src")));
 
-app.get('/api/hello', getHello);
+app.get("/api/hello", getHello);
 
-app.get('/game', (req, res) => {
+app.get("/game", (req, res) => {
+  const room_id = req.query.room_id;
+  let playersCount = req.query.players;
+
+  if (["2", "3", "4"].includes(playersCount)) {
+    playersCount = Number(playersCount);
+  } else {
+    playersCount = 4;
+  }
+  console.log(room_id, playersCount, "<-- player count");
+
+  if (!roomData.hasOwnProperty(room_id)) {
+    roomData[room_id] = { players: playersCount, tilesPlayed: [] };
+  }
+  console.log(roomData[room_id]);
+
   res.sendFile(
-    path.join(__dirname, '../..', 'phaser3-tutorial-src/prototype.html')
+    path.join(__dirname, "../..", "phaser3-tutorial-src/prototype.html")
   );
 });
 
 app.use((err, req, res, next) => {
-  console.log(err, 'error in error handling block app.js');
+  console.log(err, "error in error handling block app.js");
 
   next(err);
 });
 
-io.on('connection', (socket) => {
-  console.log('A user connected');
+io.on("connection", (socket) => {
+  console.log("A user connected");
 
-  socket.on('joinRoom', (room_id) => {
+  socket.on("joinRoom", (room_id) => {
     socket.join(room_id);
 
     if (!allGameStates.hasOwnProperty(room_id)) {
@@ -72,31 +87,31 @@ io.on('connection', (socket) => {
     console.log(`User joined room: ${room_id}`);
   });
 
-  socket.on('send_message', (data) => {
-    console.log(data, '<<<chat data');
-    socket.broadcast.emit('receive_message', data);
+  socket.on("send_message", (data) => {
+    console.log(data, "<<<chat data");
+    socket.broadcast.emit("receive_message", data);
   });
 
-  socket.on('draggedObjectPosition', (data) => {
+  socket.on("draggedObjectPosition", (data) => {
     room_id = Array.from(socket.rooms)[1];
 
     allGameStates[room_id].tilesPlayed.push(data);
 
-    io.to(room_id).emit('drag-end', data);
+    io.to(room_id).emit("drag-end", data);
   });
-  socket.on('getGameState', (room_id) => {
-    socket.emit('sendGameState', allGameStates[room_id]);
+  socket.on("getGameState", (room_id) => {
+    socket.emit("sendGameState", allGameStates[room_id]);
   });
 
-  socket.on('resetBoardServer', (room_id) => {
+  socket.on("resetBoardServer", (room_id) => {
     room_id = Array.from(socket.rooms)[1];
 
     allGameStates[room_id].tilesPlayed = [];
-    io.to(room_id).emit('resetBoardClient');
+    io.to(room_id).emit("resetBoardClient");
   });
 
-  socket.on('disconnect', () => {
-    console.log('User disconnected');
+  socket.on("disconnect", () => {
+    console.log("User disconnected");
   });
 });
 


### PR DESCRIPTION
## Pull Request Description

### Added Query Parameters
- `room_id`: If it does not exist, it will create a new one.
- `players`: An integer string between 2 and 4. Defaults to 4. If `room_id` already exists, it will ignore the `players` parameter.

### Example Usage
1. First call with a non-existing `room_id`:
   - Endpoint: `http://localhost:3000/game?room_id=abcde&players=2`
   - Result: Sets up a lobby with `room_id='abcde'` for 2 players.

2. Subsequent calls with an existing `room_id`:
   - Example: `http://localhost:3000/game?room_id=abcde&players=4`
   - Result: Adds the player to the existing lobby 'abcde' and ignores the `players` parameter.

### Screenshot
![Screenshot](https://github.com/BurakPetro/nc_group_project_ok_game/assets/28204292/5572ccb9-6a81-4813-a4d6-3f57c5f8b8f4)

### Fixes
Fixed issue #15.

