### PR TITLE
Added logic to Join game, Create game and other f-end buttons

### DIFF
--- a/client/src/components/GameSettings.jsx
+++ b/client/src/components/GameSettings.jsx
@@ -2,17 +2,8 @@ import io from 'socket.io-client';
 import Select from './Select.jsx';
 import { useState, useEffect } from 'react';
 
-const GameSettings = ({
-  gameSettingsSubmitted,
-  setGameSettingsSubmitted,
-  socket,
-}) => {
-  const [boardSize, setboardSize] = useState(17);
-  const [numberOfPlayers, setNumberOfPlayers] = useState(2);
-  const [numberOfBlocksInGame, setnumberOfBlocksInGame] = useState(10);
-  const [playerOneColor, setPlayerOneColor] = useState('red');
-
-  const [serverResponse, setServerResponce] = useState(null); // to proces server responce in future
+const GameSettings = ({ gameSettings, setGameSettings, socket }) => {
+  //const [serverResponse, setServerResponce] = useState(null); // to proces server responce in future
   /* useEffect(() => {
     socket.on('receive_message', (data) => {
       console.log(data.message);
@@ -20,22 +11,23 @@ const GameSettings = ({
     });
   }, [socket]); //TO DO specify which soket to send data*/
 
-  const sendData = (data) => {
+  /*const sendData = (data) => {
     socket.emit('send_message', { data });
-  };
+  };*/
   function handleUserGameSettingsSubmit(event) {
-    if (gameSettingsSubmitted) {
+    if (gameSettings.gameSettingsSubmitted) {
       event.preventDefault();
-      setGameSettingsSubmitted(false);
+      setGameSettings({
+        ...gameSettings,
+        gameSettingsSubmitted: false,
+      });
     } else {
       event.preventDefault();
-      const gameSettings = {};
-      gameSettings.boardSize = boardSize;
-      gameSettings.numberOfPlayers = numberOfPlayers;
-      gameSettings.numberOfBlocksInGame = numberOfBlocksInGame;
-      gameSettings.playerOneColor = playerOneColor;
-      sendData(gameSettings);
-      setGameSettingsSubmitted(true);
+      console.log(gameSettings);
+      setGameSettings({
+        ...gameSettings,
+        gameSettingsSubmitted: true,
+      });
     }
   }
 
@@ -50,10 +42,13 @@ const GameSettings = ({
             { label: 'three players', value: 3 },
             { label: 'four players', value: 4 },
           ]}
-          value={numberOfPlayers}
-          disabled={gameSettingsSubmitted}
+          value={gameSettings.numberOfPlayers}
+          disabled={gameSettings.gameSettingsSubmitted}
           onChange={(event) => {
-            setNumberOfPlayers(event.target.value);
+            setGameSettings({
+              ...gameSettings,
+              numberOfPlayers: event.target.value,
+            });
           }}
         />
         <Select
@@ -65,10 +60,13 @@ const GameSettings = ({
             { label: '20X20', value: 20 },
             { label: '25X25', value: 25 },
           ]}
-          value={boardSize}
-          disabled={gameSettingsSubmitted}
+          value={gameSettings.boardSize}
+          disabled={gameSettings.gameSettingsSubmitted}
           onChange={(event) => {
-            setboardSize(event.target.value);
+            setGameSettings({
+              ...gameSettings,
+              boardSize: event.target.value,
+            });
           }}
         />
         <Select
@@ -78,10 +76,13 @@ const GameSettings = ({
             { label: '15', value: 15 },
             { label: '20', value: 20 },
           ]}
-          value={numberOfBlocksInGame}
-          disabled={gameSettingsSubmitted}
+          value={gameSettings.numberOfBlocksInGame}
+          disabled={gameSettings.gameSettingsSubmitted}
           onChange={(event) => {
-            setnumberOfBlocksInGame(event.target.value);
+            setGameSettings({
+              ...gameSettings,
+              numberOfBlocksInGame: event.target.value,
+            });
           }}
         />
         <Select
@@ -92,15 +93,18 @@ const GameSettings = ({
             { label: 'orange', value: 'orange' },
             { label: 'green', value: 'green' },
           ]}
-          value={playerOneColor}
-          disabled={gameSettingsSubmitted}
+          value={gameSettings.playerOneColor}
+          disabled={gameSettings.gameSettingsSubmitted}
           onChange={(event) => {
-            setPlayerOneColor(event.target.value);
+            setGameSettings({
+              ...gameSettings,
+              playerOneColor: event.target.value,
+            });
           }}
         />
 
         <button type="submit">
-          {!gameSettingsSubmitted ? 'Submit' : 'Change Settings'}
+          {!gameSettings.gameSettingsSubmitted ? 'Submit' : 'Change Settings'}
         </button>
       </form>
     </>

--- a/client/src/components/LinkToJoinGame.jsx
+++ b/client/src/components/LinkToJoinGame.jsx
@@ -1,16 +1,39 @@
 import { useState, useEffect } from 'react';
-const LinkToJoinGame = ({ gameSettingsSubmitted }) => {
+const LinkToJoinGame = ({ gameSettings }) => {
   const [inputJoinLinkHolder, setInputJoinLinkHolder] = useState(
     'Your joining game link here'
   );
+  const [gameCreated, setGameCreated] = useState(false);
   const [waitingForGame, setwaitingForGame] = useState(false);
   const [joinLink, setJoinLink] = useState(
     'Create game and share link with other players'
   );
+  function generateRandomString() {
+    const alphabet = 'abcdefghijklmnopqrstuvwxyz';
+    let randomString = '';
 
+    for (let i = 0; i < 6; i++) {
+      const randomIndex = Math.floor(Math.random() * alphabet.length);
+      randomString += alphabet.charAt(randomIndex);
+    }
+
+    return randomString;
+  }
   function generateLinkForNewGame() {
     // TO DO create function to take link from serve and dislpay for user
-    setJoinLink('http://localhost:3001/');
+    if (!gameCreated) {
+      setInputJoinLinkHolder('waiting for other players');
+      setGameCreated(true);
+      setJoinLink(
+        `http://localhost:3001/game?room_id=${generateRandomString()}&players=${
+          gameSettings.numberOfPlayers
+        }`
+      );
+    } else {
+      setGameCreated(false);
+      setJoinLink('Create game and share link with other players');
+      setInputJoinLinkHolder('Your joining game link here');
+    }
   }
   function procesLinkToJoinGame() {
     // TO DO create function to take link and connect to game
@@ -33,24 +56,34 @@ const LinkToJoinGame = ({ gameSettingsSubmitted }) => {
           onChange={(event) => {
             setInputJoinLinkHolder(event.target.value);
           }}
-          disabled={waitingForGame}
+          disabled={waitingForGame ? true : gameCreated ? true : false}
         />
         {waitingForGame ? (
           <button onClick={stopWaitingForGame}>Cansel</button>
         ) : (
-          <button onClick={procesLinkToJoinGame}>Join Game</button>
+          <button disabled={gameCreated} onClick={procesLinkToJoinGame}>
+            Join Game
+          </button>
         )}
 
-        <div className="link-to-join-game">{joinLink}</div>
+        <div className="link-to-join-game">
+          {joinLink === 'Create game and share link with other players'
+            ? joinLink
+            : 'Share this link with other players ' + joinLink}
+        </div>
 
         <button
           className="create-game-button"
           onClick={generateLinkForNewGame}
           disabled={
-            waitingForGame ? true : gameSettingsSubmitted ? false : true
+            waitingForGame
+              ? true
+              : gameSettings.gameSettingsSubmitted
+              ? false
+              : true
           }
         >
-          Create game
+          {gameCreated ? 'Cansel game creation' : 'Create game'}
         </button>
         <button onClick={shortCutToSeeGame}>TemButton</button>
       </div>

--- a/client/src/components/WelcomePage.jsx
+++ b/client/src/components/WelcomePage.jsx
@@ -7,6 +7,13 @@ import moment from 'moment';
 
 const WelcomePage = () => {
   const carrentDate = moment.utc().format('LLL');
+  const [gameSettings, setGameSettings] = useState({
+    boardSize: 17,
+    numberOfPlayers: 2,
+    numberOfBlocksInGame: 10,
+    playerOneColor: 'red',
+    gameSettingsSubmitted: false,
+  });
 
   const [chatHistory, setChatHistory] = useState([
     {
@@ -14,7 +21,7 @@ const WelcomePage = () => {
       message: 'Welcom to OK game! Please treat other players with respect.',
     },
   ]);
-  const [gameSettingsSubmitted, setGameSettingsSubmitted] = useState(false);
+
   const socket = io.connect('http://localhost:3000');
   useEffect(() => {
     socket.on('receive_message', (data) => {
@@ -47,10 +54,10 @@ const WelcomePage = () => {
       </button>
       <GameSettings
         socket={socket}
-        gameSettingsSubmitted={gameSettingsSubmitted}
-        setGameSettingsSubmitted={setGameSettingsSubmitted}
+        gameSettings={gameSettings}
+        setGameSettings={setGameSettings}
       />
-      <LinkToJoinGame gameSettingsSubmitted={gameSettingsSubmitted} />
+      <LinkToJoinGame gameSettings={gameSettings} />
       <Chat
         socket={socket}
         chatHistory={chatHistory}


### PR DESCRIPTION
Form for to set game settings : number of players, board size, number of blocks, player color.

**Submit** button have next features:
when you push it changes its text to *Change Settings* . Allows to use *Create game* button. Makes all form select options disabled. *Change Settings* makes selects active and disables *Create Game*

**Join Game** button has own input. Place holder *Your joining game link here*. Logic to insert link from another player not done yet. When pressed makes *Create Game* disabled. Changes its text to *Cancel* . Makes input disabled , changes inputs text to *waiting for other players*. *Cancel* restores original state of all mentioned.

**Create Game** disabled unless settings were submitted. Generates link for other player to join. Changes text from *Create game and share link with other players* to *Share this link with other players http://localhost:3000/game?room_id={5 random letters to create room id}&players={number of players}*. On activation changes its own text to *Cancel game creation*. Second activation restore mentioned changes.

**TemButton** dev only, to remove during deploy. Shortcut, goes directly to game board.

**Send Message** takes text from input, sends it to other visitors of this page using socet.io on server side. Server must be on.
CORES are set to allow all for dev purposes, to change during deploy.
*?* lids to instruction page


Known issues: 
typo on Cancel
chat loses messages after more then 3-5 where posted.
date format on chat message to be corrected
login button not implemented
 
