### PR TITLE
Added separate shell commands for running project environment in either development or production

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "NODE_ENV=development vite",
+    "start": "NODE_ENV=production vite",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"

--- a/client/src/components/ExampleInterface.jsx
+++ b/client/src/components/ExampleInterface.jsx
@@ -2,7 +2,12 @@ import { useState, useEffect } from 'react';
 import io from 'socket.io-client';
 
 const ExampleInterface = ({ setgameSettings }) => {
-  const socket = io.connect('https://ok-game.onrender.com/game');
+  let socket;
+  if (process.env.NODE_ENV === 'development') {
+    socket = io.connect('http://localhost:3001')
+  } else {
+    socket = io.connect('https://ok-game.onrender.com/game');
+  }
   const [message, setMessage] = useState('');
   const [boardSize, setboardSize] = useState(10);
   const [massageReceived, setMessageReceived] = useState('');

--- a/client/src/components/Game.jsx
+++ b/client/src/components/Game.jsx
@@ -2,7 +2,13 @@ import React, { useEffect } from 'react';
 import Phaser from 'phaser';
 //import sceneWrap from './scenes/ExampleScene.js';
 import io from 'socket.io-client';
-const socket = io.connect('https://ok-game.onrender.com/game');
+
+let socket;
+  if (process.env.NODE_ENV === 'development') {
+    socket = io.connect('http://localhost:3001')
+  } else {
+    socket = io.connect('https://ok-game.onrender.com/game');
+  }
 
 function Game({ gameSettings, setgameSettings }) {
   let game = null;

--- a/client/src/components/GameSettings.jsx
+++ b/client/src/components/GameSettings.jsx
@@ -1,7 +1,7 @@
 const GameSettings = ({ gameSettings, setGameSettings }) => {
   return (
     <>
-      <h2>Chose your settings to create a new game</h2>
+      <h2>Choose your settings to create a new game</h2>
       <div className="setting-line">
         <div className="settings-first-row">
           <div className="chose-number-of-players">

--- a/client/src/components/LinkToJoinGame.jsx
+++ b/client/src/components/LinkToJoinGame.jsx
@@ -16,6 +16,9 @@ const LinkToJoinGame = () => {
   const [joinLink, setJoinLink] = useState(
     "Create game and share link with other players"
   );
+
+  let devServer = "http://localhost:3000/game";
+
   function generateRandomString() {
     const alphabet = "abcdefghijklmnopqrstuvwxyz";
     let randomString = "";
@@ -29,11 +32,20 @@ const LinkToJoinGame = () => {
   }
   function generateLinkForNewGame() {
     // TO DO create function to take link from serve and dislpay for user
-    if (!gameCreated) {
+    if (!gameCreated && process.env.NODE_ENV === 'development') {
       setInputJoinLinkHolder("waiting for other players");
       setGameCreated(true);
       setJoinLink(
-        `https://ok-game.onrender.com/game?room_id=${generateRandomString()}&players=${
+        `${devServer}?room_id=${generateRandomString()}&players=${
+          gameSettings.numberOfPlayers
+        }`
+      );
+    } else if (!gameCreated && process.env.NODE_ENV === 'production') {
+      devServer = 'https://ok-game.onrender.com/game'
+      setInputJoinLinkHolder("waiting for other players");
+      setGameCreated(true);
+      setJoinLink(
+        `${devServer}?room_id=${generateRandomString()}&players=${
           gameSettings.numberOfPlayers
         }`
       );

--- a/client/src/components/WelcomePage.jsx
+++ b/client/src/components/WelcomePage.jsx
@@ -12,11 +12,17 @@ const WelcomePage = () => {
   const [chatHistory, setChatHistory] = useState([
     {
       date: carrentDate,
-      message: "Welcom to OK game! Please treat other players with respect.",
+      message: "Welcome to OK play! Please treat other players with respect.",
     },
   ]);
 
-  const socket = io.connect("https://ok-game.onrender.com/game");
+  let socket;
+  if (process.env.NODE_ENV === 'development') {
+    socket = io.connect('http://localhost:3000')
+  } else {
+    socket = io.connect('https://ok-game.onrender.com/game');
+  }
+
   useEffect(() => {
     socket.on("receive_message", (data) => {
       console.log(data.chatMessage);


### PR DESCRIPTION
I've added a `start` script in `/client/package.json` that when ran, will set `NODE_ENV` to production and will navigate to the deployed version of the game when a user attempts to create a game. When `npm run dev` is now ran, `NODE_ENV` will be set to development and the user will now instead run the game on `localhost` when they create a game. All changes are on `./client`.